### PR TITLE
Use OpenSSL::Cipher instead of OpenSSL::Cipher::Cipher

### DIFF
--- a/lib/block_io.rb
+++ b/lib/block_io.rb
@@ -354,7 +354,7 @@ module BlockIo
       response = nil
 
       begin
-        aes = OpenSSL::Cipher::Cipher.new(cipher_type)
+        aes = OpenSSL::Cipher.new(cipher_type)
         aes.decrypt
         aes.key = Base64.strict_decode64(b64_enc_key)
         aes.iv = iv if iv != nil
@@ -369,7 +369,7 @@ module BlockIo
     
     # Encrypts a block of data given an encryption key
     def self.encrypt(data, b64_enc_key, iv = nil, cipher_type = 'AES-256-ECB')
-      aes = OpenSSL::Cipher::Cipher.new(cipher_type)
+      aes = OpenSSL::Cipher.new(cipher_type)
       aes.encrypt
       aes.key = Base64.strict_decode64(b64_enc_key)
       aes.iv = iv if iv != nil


### PR DESCRIPTION
`warning: constant OpenSSL::Cipher::Cipher is deprecated` 

@doersf will you please review? 